### PR TITLE
Interface code to the Adafruit TSL2561 module

### DIFF
--- a/tsl2561.lux.py
+++ b/tsl2561.lux.py
@@ -2,13 +2,21 @@
 # coding=latin1
 
 '''
-This plugin requires the Dataloop agent to be in the spi and i2c groups or to be run as root.
+This plugin requires the Dataloop agent user to be in the spi and i2c groups or to be run as root.
 
 The Adafruit TSL2561 directory available as part of the Pi 2 Python library from
 
-https://github.com/adafruit/Adafruit-Raspberry-Pi-Python-Code
+https://github.com/IainColledge/Adafruit-Raspberry-Pi-Python-Code
 
-Should be copied to the dataloop plugins directory /opt/dataloop/plugins and a blank file __init__.py added
+Will update to use the Adafruit library when they accept one of two TSL2561 module pull requests.
+
+The directory should be copied to the dataloop plugins directory /opt/dataloop/plugins and a blank file __init__.py added
+then this file should be copied to /opt/dataloop/plugins so the file structure looks like
+
+tsl2561.lux.py
+Adafruit_TSL2561/Adafruit_I2C.py
+Adafruit_TSL2561/Adafruit_TSL2561.py
+Adafruit_TSL2561/__init__.py
 
 Iain Colledge
 '''

--- a/tsl2561.lux.py
+++ b/tsl2561.lux.py
@@ -4,7 +4,7 @@
 '''
 This plugin requires the Dataloop agent user to be in the spi and i2c groups or to be run as root.
 
-The Adafruit TSL2561 directory available as part of the Pi 2 Python library from
+The Adafruit TSL2561 directory available as part of the Raspberry Pi Python library from
 
 https://github.com/IainColledge/Adafruit-Raspberry-Pi-Python-Code
 

--- a/tsl2561.lux.py
+++ b/tsl2561.lux.py
@@ -18,4 +18,4 @@ import Adafruit_TSL2561.Adafruit_TSL2561 as Adafruit_TSL2561
 LightSensor = Adafruit_TSL2561.Adafruit_TSL2651()
 LightSensor.enableAutoGain(True)
 
-print "OK| lux=%d%%;;;;" % (int(LightSensor.calculateAvgLux()))
+print "OK| lux=%d;;;;" % (int(LightSensor.calculateAvgLux()))

--- a/tsl2561.lux.py
+++ b/tsl2561.lux.py
@@ -1,0 +1,21 @@
+#!/usr/bin/env python
+# coding=latin1
+
+'''
+This plugin requires the Dataloop agent to be in the spi and i2c groups or to be run as root.
+
+The Adafruit TSL2561 directory available as part of the Pi 2 Python library from
+
+https://github.com/adafruit/Adafruit-Raspberry-Pi-Python-Code
+
+Should be copied to the dataloop plugins directory /opt/dataloop/plugins and a blank file __init__.py added
+
+Iain Colledge
+'''
+
+import Adafruit_TSL2561.Adafruit_TSL2561 as Adafruit_TSL2561
+
+LightSensor = Adafruit_TSL2561.Adafruit_TSL2651()
+LightSensor.enableAutoGain(True)
+
+print "OK| lux=%d%%;;;;" % (int(LightSensor.calculateAvgLux()))


### PR DESCRIPTION
Allows measurement of lux readings from the TSL2561 sensor.

Uses the Adafruit TSL2561 module although there are two pull requests to their repo so will update to whichever one they choose to use. Has instructions on how to set up.

Checked against a cheap lux meter and was in 10% of each other so reading are in the ballpark.
